### PR TITLE
Add wilton logger support for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,24 @@ option ( ${PROJECT_NAME}_DISABLE_LOGGING "Disable logging to std out and err" OF
 option ( ${PROJECT_NAME}_USE_LOG4CPLUS "Use log4cplus lib for logging" OFF )
 option ( ${PROJECT_NAME}_USE_OPENSSL "Use OpenSSL lib for https" OFF )
 
+option ( ${PROJECT_NAME}_USE_WILTON_LOG "Use wilton_logging lib for logging" ON )
+
 # standalone build
 if ( NOT DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY )
     set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
 endif ( )
+
+if ( ${PROJECT_NAME}_USE_WILTON_LOG )
+    message(STATUS "*** NOT STATICLIB_TOOLCHAIN MATCHES ${STATICLIB_TOOLCHAIN}")
+    message(STATUS "*** ${CMAKE_CURRENT_LIST_DIR}/../../modules/wilton_logging")
+    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../../modules/wilton_logging )
+    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_LIST_DIR}/../../modules/wilton_logging/include)
+    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_LIST_DIR}/../../core/include)
+    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../staticlib_concurrent )
+    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../staticlib_utils )
+    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../external_asio )
+endif ( )
+
 if ( NOT DEFINED STATICLIB_TOOLCHAIN )
     if ( NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
         staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../external_asio )
@@ -76,6 +90,9 @@ if ( ${PROJECT_NAME}_USE_LOG4CPLUS )
 endif ( )
 if ( ${PROJECT_NAME}_USE_OPENSSL )
     list ( APPEND ${PROJECT_NAME}_DEPS openssl )
+endif ( )
+if ( ${PROJECT_NAME}_USE_WILTON_LOG )
+    list ( APPEND ${PROJECT_NAME}_DEPS wilton_logging )
 endif ( )
 staticlib_pion_pkg_check_modules ( ${PROJECT_NAME}_DEPS_PC REQUIRED ${PROJECT_NAME}_DEPS )
 
@@ -110,6 +127,11 @@ endif ( )
 if ( ${PROJECT_NAME}_USE_LOG4CPLUS )
     set ( ${PROJECT_NAME}_DEFINITIONS ${${PROJECT_NAME}_DEFINITIONS} -DSTATICLIB_PION_USE_LOG4CPLUS )
     set ( ${PROJECT_NAME}_CFLAGS_PUBLIC ${${PROJECT_NAME}_CFLAGS_PUBLIC} -DSTATICLIB_PION_USE_LOG4CPLUS )
+endif ( )
+
+if ( ${PROJECT_NAME}_USE_WILTON_LOG )
+    set ( ${PROJECT_NAME}_DEFINITIONS ${${PROJECT_NAME}_DEFINITIONS} -DSTATICLIB_PION_USE_WILTON_LOG )
+    set ( ${PROJECT_NAME}_CFLAGS_PUBLIC ${${PROJECT_NAME}_CFLAGS_PUBLIC} -DSTATICLIB_PION_USE_WILTON_LOG )
 endif ( )
 
 if ( ${PROJECT_NAME}_USE_OPENSSL )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,22 +44,9 @@ option ( ${PROJECT_NAME}_DISABLE_LOGGING "Disable logging to std out and err" OF
 option ( ${PROJECT_NAME}_USE_LOG4CPLUS "Use log4cplus lib for logging" OFF )
 option ( ${PROJECT_NAME}_USE_OPENSSL "Use OpenSSL lib for https" OFF )
 
-option ( ${PROJECT_NAME}_USE_WILTON_LOG "Use wilton_logging lib for logging" ON )
-
 # standalone build
 if ( NOT DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY )
     set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
-endif ( )
-
-if ( ${PROJECT_NAME}_USE_WILTON_LOG )
-    message(STATUS "*** NOT STATICLIB_TOOLCHAIN MATCHES ${STATICLIB_TOOLCHAIN}")
-    message(STATUS "*** ${CMAKE_CURRENT_LIST_DIR}/../../modules/wilton_logging")
-    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../../modules/wilton_logging )
-    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_LIST_DIR}/../../modules/wilton_logging/include)
-    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_LIST_DIR}/../../core/include)
-    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../staticlib_concurrent )
-    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../staticlib_utils )
-    staticlib_pion_add_subdirectory ( ${CMAKE_CURRENT_LIST_DIR}/../external_asio )
 endif ( )
 
 if ( NOT DEFINED STATICLIB_TOOLCHAIN )
@@ -91,9 +78,7 @@ endif ( )
 if ( ${PROJECT_NAME}_USE_OPENSSL )
     list ( APPEND ${PROJECT_NAME}_DEPS openssl )
 endif ( )
-if ( ${PROJECT_NAME}_USE_WILTON_LOG )
-    list ( APPEND ${PROJECT_NAME}_DEPS wilton_logging )
-endif ( )
+
 staticlib_pion_pkg_check_modules ( ${PROJECT_NAME}_DEPS_PC REQUIRED ${PROJECT_NAME}_DEPS )
 
 # library
@@ -129,11 +114,6 @@ if ( ${PROJECT_NAME}_USE_LOG4CPLUS )
     set ( ${PROJECT_NAME}_CFLAGS_PUBLIC ${${PROJECT_NAME}_CFLAGS_PUBLIC} -DSTATICLIB_PION_USE_LOG4CPLUS )
 endif ( )
 
-if ( ${PROJECT_NAME}_USE_WILTON_LOG )
-    set ( ${PROJECT_NAME}_DEFINITIONS ${${PROJECT_NAME}_DEFINITIONS} -DSTATICLIB_PION_USE_WILTON_LOG )
-    set ( ${PROJECT_NAME}_CFLAGS_PUBLIC ${${PROJECT_NAME}_CFLAGS_PUBLIC} -DSTATICLIB_PION_USE_WILTON_LOG )
-endif ( )
-
 if ( ${PROJECT_NAME}_USE_OPENSSL )
     set ( ${PROJECT_NAME}_DEFINITIONS ${${PROJECT_NAME}_DEFINITIONS} -DSTATICLIB_PION_HAVE_SSL )
     set ( ${PROJECT_NAME}_CFLAGS_PUBLIC ${${PROJECT_NAME}_CFLAGS_PUBLIC} -DSTATICLIB_PION_HAVE_SSL )
@@ -161,8 +141,13 @@ if ( ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" )
     set ( ${PROJECT_NAME}_CFLAGS_PUBLIC ${${PROJECT_NAME}_CFLAGS_PUBLIC} -Wno-unused-variable )
 endif ( )
 
+if ( ${PROJECT_NAME}_WILTON_LOG_INCLUDE )
+  set ( ${PROJECT_NAME}_DEFINITIONS ${${PROJECT_NAME}_DEFINITIONS} -DSTATICLIB_PION_USE_WILTON_LOG )
+endif ( )
+
 target_include_directories ( ${PROJECT_NAME} BEFORE PRIVATE 
         ${CMAKE_CURRENT_LIST_DIR}/include
+        ${${PROJECT_NAME}_WILTON_LOG_INCLUDE}
         ${${PROJECT_NAME}_DEPS_PC_INCLUDE_DIRS} )
 
 target_compile_definitions ( ${PROJECT_NAME} PRIVATE ${${PROJECT_NAME}_DEFINITIONS} )
@@ -175,6 +160,9 @@ target_compile_options ( ${PROJECT_NAME} PRIVATE
 staticlib_pion_list_to_string ( ${PROJECT_NAME}_PC_CFLAGS_OTHER "" ${PROJECT_NAME}_CFLAGS_PUBLIC )
 set ( ${PROJECT_NAME}_PC_CFLAGS "-I${CMAKE_CURRENT_LIST_DIR}/include ${${PROJECT_NAME}_PC_CFLAGS_OTHER}" )
 set ( ${PROJECT_NAME}_PC_LIBS "-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY} -l${PROJECT_NAME}" )
+if(${PROJECT_NAME}_WILTON_LOG_LIB)
+  set ( ${PROJECT_NAME}_PC_LIBS "${${PROJECT_NAME}_PC_LIBS} -L${${PROJECT_NAME}_WILTON_LOG_LIB} -lwilton_logging" )
+endif()
 if ( CMAKE_SYSTEM_NAME STREQUAL "Linux" )
     set ( ${PROJECT_NAME}_PC_LIBS "${${PROJECT_NAME}_PC_LIBS} -lpthread" )
 endif ( )

--- a/include/staticlib/pion/logger.hpp
+++ b/include/staticlib/pion/logger.hpp
@@ -32,69 +32,23 @@
 
 #include "wilton/wilton_logging.h"
 #include <string>
-#include <ctime>
-#include <vector>
-#include <atomic>
 
 namespace staticlib {
 namespace pion {
 
 namespace {
-    std::atomic<bool> is_init(false);
-    const auto staticlib_pion_logger = std::string{"\"staticlib.pion\" : \"DEBUG\""};
-
-    std::string get_loggers(){
-        return staticlib_pion_logger;
-    }
-
-    std::string get_appenders(){
-        std::vector<std::string> appenders;
-        appenders.push_back("DEBUG");
-        appenders.push_back("INFO");
-        appenders.push_back("WARN");
-        appenders.push_back("ERROR");
-        appenders.push_back("FATAL");
-        auto res = std::string{};
-        for (auto el : appenders) {
-            std::string row =  "{ \n\
-                  \"appenderType\": \"CONSOLE\", \n\
-                  \"layout\": \"%d{%Y-%m-%d %H:%M:%S,%q} [%-5p %-5.5t %-20.20c] %m%n\", \n\
-                  \"thresholdLevel\": \"" + el + "\" \n\
-              },\n";
-            res.append(row);
-        }
-        res.pop_back();
-        res.pop_back();
-        return res;
-    }
-    void initLogger(){
-        if (is_init.exchange(true)) return;
-
-        std::string json_str =
-            "{ \n\
-                \"appenders\": [" + get_appenders() + " ], \n\
-                \"loggers\": {" + get_loggers() + "}  \n\
-            }";
-        wilton_logger_initialize(json_str.c_str(), json_str.size());
-    }
-
+    const std::string LOG_LEVEL_DEBUG("DEBUG");
+    const std::string LOG_LEVEL_INFO("INFO");
+    const std::string LOG_LEVEL_WARN("WARN");
+    const std::string LOG_LEVEL_ERROR("ERROR");
+    const std::string LOG_LEVEL_FATAL("FATAL");
 }
+
 /**
  *  logger implementation for wilton_logger use
  */
 class logger {
 public:
-
-    /**
-     * Supported log levels
-     */
-    enum log_priority_type {
-        LOG_LEVEL_DEBUG,
-        LOG_LEVEL_INFO,
-        LOG_LEVEL_WARN,
-        LOG_LEVEL_ERROR,
-        LOG_LEVEL_FATAL
-    };
 
     /**
      * Logger name
@@ -105,7 +59,6 @@ public:
      * Constructor, returns logger with name "pion"
      */
     logger() : m_name("staticlib.pion") {
-        initLogger();
     }
 
     /**
@@ -114,7 +67,6 @@ public:
      * @param name logger name
      */
     logger(const std::string& name) : m_name(name) {
-        initLogger();
     }
 
     /**
@@ -147,34 +99,29 @@ public:
 
 // Logging api, used in pion, send MSG as [str1 << str2], ostringstream used to handle it.
 #define STATICLIB_PION_LOG_DEBUG(LOG, MSG)    \
-    if (LOG.is_priority_enabled("DEBUG")) { \
-    std::ostringstream test; \
-    test << MSG; \
-    LOG.log("DEBUG", test.str());}
+    { std::ostringstream msg_handler; \
+    msg_handler << MSG; \
+    LOG.log(LOG_LEVEL_DEBUG, msg_handler.str());}
 
 #define STATICLIB_PION_LOG_INFO(LOG, MSG)     \
-    if (LOG.is_priority_enabled("INFO")) { \
-    std::ostringstream test; \
-    test << MSG; \
-    LOG.log("INFO", test.str());}
+    { std::ostringstream msg_handler; \
+    msg_handler << MSG; \
+    LOG.log(LOG_LEVEL_INFO, msg_handler.str());}
 
 #define STATICLIB_PION_LOG_WARN(LOG, MSG)    \
-    if (LOG.is_priority_enabled("WARN")) { \
-    std::ostringstream test; \
-    test << MSG; \
-    LOG.log("WARN", test.str());}
+    { std::ostringstream msg_handler; \
+    msg_handler << MSG; \
+    LOG.log(LOG_LEVEL_WARN, msg_handler.str());}
 
 #define STATICLIB_PION_LOG_ERROR(LOG, MSG)    \
-    if (LOG.is_priority_enabled("ERROR")) { \
-    std::ostringstream test; \
-    test << MSG; \
-    LOG.log("ERROR", test.str());}
+    { std::ostringstream msg_handler; \
+    msg_handler << MSG; \
+    LOG.log(LOG_LEVEL_ERROR, msg_handler.str());}
 
 #define STATICLIB_PION_LOG_FATAL(LOG, MSG)    \
-    if (LOG.is_priority_enabled("FATAL")) { \
-    std::ostringstream test; \
-    test << MSG; \
-    LOG.log("FATAL", test.str());}
+    { std::ostringstream msg_handler; \
+    msg_handler << MSG; \
+    LOG.log(LOG_LEVEL_FATAL, msg_handler.str());}
 
 // define dumb level change functions
 #define STATICLIB_PION_LOG_SETLEVEL_DEBUG(LOG)    { LOG.do_nothing(); }


### PR DESCRIPTION
To enable wilton_logging support project need to define cmake variables: staticlib_pion_WILTON_LOG_INCLUDE and staticlib_pion_WILTON_LOG_LIB.
example for wilton_server:
set (staticlib_pion_WILTON_LOG_INCLUDE 
       "${WILTON_DIR}/modules/wilton_logging/include;${WILTON_DIR}/core/include")
set (staticlib_pion_WILTON_LOG_LIB 
       "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")